### PR TITLE
loadingRecords is not working with responsive plugin.

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -263,9 +263,6 @@ $.extend( Responsive.prototype, {
 				dt.columns.adjust();
 			}
 		} );
-
-		// First pass - draw the table for the current viewport size
-		this._resize();
 	},
 
 


### PR DESCRIPTION
loadingRecords is not working with responsive plugin.

Details: 
Inside _constructor _resize is called before dt is initialize.
```
// First pass - draw the table for the current viewport size
this._resize();
```
which internally calls `dt.draw()` and increments `iDraw` counter.

Condition to use loadingRecords is like
```
if ( oSettings.iDraw == 1 &&  _fnDataSource( oSettings ) == 'ajax' )
{
     sZero = oLang.sLoadingRecords;
}
```
